### PR TITLE
役割選択ページ作成、パートナーカレンダーページ作成、サインインしたあとの遷移先を役割選択ページに変更

### DIFF
--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -33,7 +33,7 @@ export default function Login() {
       if (response.ok) {
         console.log("response.ok:", response.ok);
         console.log("Google認証時POSTされたデータ:", userData);
-        router.push("/calendar");
+        router.push("/role");
       } else {
         throw new Error("Failed to save user data");
       }

--- a/front/src/app/partner/page.tsx
+++ b/front/src/app/partner/page.tsx
@@ -1,0 +1,7 @@
+export default function Partner() {
+  return (
+    <>
+      <h2>パートナーカレンダーページ</h2>
+    </>
+  );
+}

--- a/front/src/app/role/page.tsx
+++ b/front/src/app/role/page.tsx
@@ -1,0 +1,31 @@
+export default function Role() {
+  return (
+    <>
+      <div className="flex flex-col items-center justify-center min-h-screen">
+        <div>
+          <h2 className="text-center mb-6">タイプを選択してください</h2>
+
+          <div className="flex flex-col space-y-6">
+            <button className="for-woman border-2 border-black hover:border-orange-500 rounded-lg p-4 transition-colors duration-300">
+              <p className="font-bold mb-2">女性</p>
+              <p>
+                治療の記録や治療金額の見積もり、カウンセリングなどを利用できます。
+                <br />
+                また、治療に向けたメッセージも受け取ることができます。
+              </p>
+            </button>
+
+            <button className="for-partner border-2 border-black hover:border-orange-500 rounded-lg p-4 transition-colors duration-300 mt-2.5">
+              <p className="font-bold mb-2">パートナー</p>
+              <p>
+                女性版で入力されたスケジュールを閲覧できます。
+                <br />
+                また、治療のサポートに向けたメッセージを受け取ることができます。
+              </p>
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
issue: #24 
- [ ]  役割選択画面作成

## 追加・変更内容
- 役割選択画面作成(role.page)
- パートナーカレンダーページ作成(partner/page)
- サインイン(login/page)したあとの遷移先を役割選択ページに変更

## その他
- 